### PR TITLE
Traces in Jest execution - verbose

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "web-ext": "^6.1.0",
     "webpack": "^5.42.0",
     "webpack-cli": "^4.7.2"
+  },
+  "jest": {
+    "verbose": true
   }
 }


### PR DESCRIPTION
This pull request adds the logs to the traces of Jest execution.
It configurates the Jest with the `verbose` property set to true in *package.json*, so that the traces are now printed with the increased logs with each test executed in each file.
