### PR TITLE
Use React to redesign the popup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,8 @@
             {
                 "endOfLine": "auto"
             }
-        ]
+        ],
+        "react/prop-types": 0
     },
     "plugins": [
         "prettier"

--- a/app/src/engine/Database.js
+++ b/app/src/engine/Database.js
@@ -69,7 +69,11 @@ class Database {
 
     loadSessions() {
         const sessionsArray = this.storage.getItem("sessions");
-        return JSON.parse(sessionsArray);
+        if(sessionsArray) {
+            return JSON.parse(sessionsArray);
+        } else {
+            return [];
+        }
     }
 
     saveSessions(allSessionsArray) {

--- a/app/src/engine/Database.js
+++ b/app/src/engine/Database.js
@@ -69,7 +69,7 @@ class Database {
 
     loadSessions() {
         const sessionsArray = this.storage.getItem("sessions");
-        if(sessionsArray) {
+        if (sessionsArray) {
             return JSON.parse(sessionsArray);
         } else {
             return [];

--- a/app/src/popup/MainPopup.css
+++ b/app/src/popup/MainPopup.css
@@ -7,7 +7,7 @@ html, body {
   }
 
   .panel-session-name {
-    height: 45%;
+    height: 50;
     display: flex;
     justify-content: center;
   }
@@ -25,9 +25,29 @@ html, body {
   }
 
   .panel-actions {
-    display: flex;
-    height: 45%;
+    display: grid;
+    grid-area: button;
+    grid-gap: 10px;
+    flex-direction: row;
     justify-content: space-around;
+  }
+
+  form {
+    background-color: #f2f2f2;
+    display: grid;
+    grid-gap: 30px;
+    grid-template-areas:
+      'header header header'
+      'input input button'
+      'blank blank button';
+  }
+
+  .panel-session-name {
+    grid-area: input;
+  }
+
+  .panel-plugin-name {
+    grid-area: header;
   }
 
   .session-name-input {
@@ -52,8 +72,8 @@ html, body {
 
   button {
     border-radius: 10px;
-    margin: 10px;
-    padding: 10px;
+    height: 40px;
+    padding: 5px;
     cursor: pointer;
     background-image: radial-gradient( white, lightblue);
     border: 1px solid transparent;
@@ -61,6 +81,6 @@ html, body {
   }
 
   button:hover {
-    border-radius: 50px;
+    border-radius: 30px;
     border: 1px solid blue;
   }

--- a/app/src/popup/MainPopup.css
+++ b/app/src/popup/MainPopup.css
@@ -33,12 +33,6 @@ html, body {
   .session-name-input {
     width: 90%;
     margin: 10px;
-    border-color: grey;
-  }
-
-  input[type=text] {
-    width: 90%;
-    margin: 10px;
     border-top-width: 0px;
     border-left-width: 0px;
     border-right-width: 0px;

--- a/app/src/popup/MainPopup.js
+++ b/app/src/popup/MainPopup.js
@@ -1,6 +1,7 @@
 import * as logic from "./MainPopupLogic";
 import * as React from "react";
 import ReactDOM from "react-dom";
+import ExpandedSessionListInput from "./components/ExpandedSessionListInput";
 
 export class MainPopup extends React.Component {
     constructor(props) {
@@ -19,8 +20,7 @@ export class MainPopup extends React.Component {
 
                 <form id="mainForm">
                     <div className="panel-session-name">
-                        <input id="sessionNameInput" list="sessions" type="text" placeholder="..." autoFocus />
-                        <datalist id="sessions"></datalist>
+                        <ExpandedSessionListInput />
                     </div>
                     <div className="panel-actions">
                         <button type="submit" id="saveButton">

--- a/app/src/popup/MainPopup.js
+++ b/app/src/popup/MainPopup.js
@@ -14,22 +14,19 @@ export class MainPopup extends React.Component {
 
     render() {
         return (
-            <div id="popup-content">
+            <form id="mainForm">
                 <div className="panel-plugin-name">
                     <a href="https://github.com/BartoszKlonowski/session-storage">{this.state.extensionName}</a>
                 </div>
-
-                <form id="mainForm">
-                    <div className="panel-session-name">
-                        <ExpandedSessionListInput />
-                    </div>
-                    <div className="panel-actions">
-                        <ActionButton name="saveButton" text="SAVE" icon="glyphicon glyphicon-floppy-disk" />
-                        <ActionButton name="deleteButton" text="DELETE" icon="glyphicon glyphicon-trash" />
-                        <ActionButton name="reopenButton" text="REOPEN" icon="glyphicon glyphicon-refresh" />
-                    </div>
-                </form>
-            </div>
+                <div className="panel-session-name">
+                    <ExpandedSessionListInput />
+                </div>
+                <div className="panel-actions">
+                    <ActionButton name="saveButton" text="SAVE" icon="glyphicon glyphicon-floppy-disk" />
+                    <ActionButton name="deleteButton" text="DELETE" icon="glyphicon glyphicon-trash" />
+                    <ActionButton name="reopenButton" text="REOPEN" icon="glyphicon glyphicon-refresh" />
+                </div>
+            </form>
         );
     }
 }

--- a/app/src/popup/MainPopup.js
+++ b/app/src/popup/MainPopup.js
@@ -18,9 +18,7 @@ export class MainPopup extends React.Component {
                 <div className="panel-plugin-name">
                     <a href="https://github.com/BartoszKlonowski/session-storage">{this.state.extensionName}</a>
                 </div>
-                <div className="panel-session-name">
-                    <ExpandedSessionListInput />
-                </div>
+                <ExpandedSessionListInput />
                 <div className="panel-actions">
                     <ActionButton name="saveButton" text="SAVE" icon="glyphicon glyphicon-floppy-disk" />
                     <ActionButton name="deleteButton" text="DELETE" icon="glyphicon glyphicon-trash" />

--- a/app/src/popup/MainPopup.js
+++ b/app/src/popup/MainPopup.js
@@ -2,6 +2,7 @@ import * as logic from "./MainPopupLogic";
 import * as React from "react";
 import ReactDOM from "react-dom";
 import ExpandedSessionListInput from "./components/ExpandedSessionListInput";
+import ActionButton from "./components/ActionButton";
 
 export class MainPopup extends React.Component {
     constructor(props) {
@@ -23,15 +24,9 @@ export class MainPopup extends React.Component {
                         <ExpandedSessionListInput />
                     </div>
                     <div className="panel-actions">
-                        <button type="submit" id="saveButton">
-                            <i className="glyphicon glyphicon-floppy-disk"></i>
-                        </button>
-                        <button type="submit" id="deleteButton">
-                            <i className="glyphicon glyphicon-trash"></i>
-                        </button>
-                        <button type="submit" id="reopenButton">
-                            <i className="glyphicon glyphicon-refresh"></i>
-                        </button>
+                        <ActionButton name="saveButton" text="SAVE" icon="glyphicon glyphicon-floppy-disk" />
+                        <ActionButton name="deleteButton" text="DELETE" icon="glyphicon glyphicon-trash" />
+                        <ActionButton name="reopenButton" text="REOPEN" icon="glyphicon glyphicon-refresh" />
                     </div>
                 </form>
             </div>

--- a/app/src/popup/MainPopup.js
+++ b/app/src/popup/MainPopup.js
@@ -3,6 +3,7 @@ import * as React from "react";
 import ReactDOM from "react-dom";
 import ExpandedSessionListInput from "./components/ExpandedSessionListInput";
 import ActionButton from "./components/ActionButton";
+import Logo from "./components/Logo";
 
 export class MainPopup extends React.Component {
     constructor(props) {
@@ -15,9 +16,7 @@ export class MainPopup extends React.Component {
     render() {
         return (
             <form id="mainForm">
-                <div className="panel-plugin-name">
-                    <a href="https://github.com/BartoszKlonowski/session-storage">{this.state.extensionName}</a>
-                </div>
+                <Logo extensionName="Session Storage" />
                 <ExpandedSessionListInput />
                 <div className="panel-actions">
                     <ActionButton name="saveButton" text="SAVE" icon="glyphicon glyphicon-floppy-disk" />

--- a/app/src/popup/MainPopupLogic.js
+++ b/app/src/popup/MainPopupLogic.js
@@ -27,7 +27,7 @@ export function handleEventForGivenTab(browser, tabs, event, session) {
 }
 
 export function getSessionNameFromInput(document) {
-    const sessionName = document.getElementById("sessionNameInput").value;
+    const sessionName = document.getElementsByClassName("session-name-input")[0].value;
     return sessionName;
 }
 

--- a/app/src/popup/components/ActionButton.js
+++ b/app/src/popup/components/ActionButton.js
@@ -3,11 +3,18 @@ import React from "react";
 export class ActionButton extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {};
+        this.state = {
+        };
     }
 
     render() {
-        return <></>;
+        return (
+            <>
+                <button type="submit" title={this.props.text} id={this.props.name}>
+                    <i className={this.props.icon}></i>
+                </button>
+            </>
+        );
     }
 }
 

--- a/app/src/popup/components/ActionButton.js
+++ b/app/src/popup/components/ActionButton.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+export class ActionButton extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            name: props.name
+        };
+    }
+
+    render() {
+        return(
+            <>
+            </>
+        );
+    }
+}
+
+export default ActionButton;

--- a/app/src/popup/components/ActionButton.js
+++ b/app/src/popup/components/ActionButton.js
@@ -3,16 +3,11 @@ import React from "react";
 export class ActionButton extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {
-            name: props.name
-        };
+        this.state = {};
     }
 
     render() {
-        return(
-            <>
-            </>
-        );
+        return <></>;
     }
 }
 

--- a/app/src/popup/components/ActionButton.js
+++ b/app/src/popup/components/ActionButton.js
@@ -10,7 +10,7 @@ export class ActionButton extends React.Component {
         return (
             <>
                 <button type="submit" title={this.props.text} id={this.props.name}>
-                    <i className={this.props.icon}></i>
+                    <i id={this.props.name} className={this.props.icon}></i>
                 </button>
             </>
         );

--- a/app/src/popup/components/ActionButton.js
+++ b/app/src/popup/components/ActionButton.js
@@ -10,7 +10,7 @@ export class ActionButton extends React.Component {
         return (
             <>
                 <button type="submit" title={this.props.text} id={this.props.name}>
-                    <i id={this.props.name} className={this.props.icon}></i>
+                    <i id={this.props.name} className={this.props.icon}></i> {this.props.text}
                 </button>
             </>
         );

--- a/app/src/popup/components/ActionButton.js
+++ b/app/src/popup/components/ActionButton.js
@@ -3,8 +3,7 @@ import React from "react";
 export class ActionButton extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {
-        };
+        this.state = {};
     }
 
     render() {

--- a/app/src/popup/components/ExpandedSessionListInput.js
+++ b/app/src/popup/components/ExpandedSessionListInput.js
@@ -5,17 +5,24 @@ export class ExpandedSessionListInput extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            sessions: []
+            sessions: [],
         };
     }
 
     componentDidMount() {
         const storage = new Database();
+        this.setState({sessions: storage.loadSessions()});
     }
 
     render() {
-        return(
+        let options = [];
+        for (const sessionName of this.state.sessions) {
+            options.push(<option value={sessionName}></option>);
+        }
+        return (
             <>
+                <input list="allSessions" type="text" className="session-name-input" placeholder="..." />
+                <datalist id="allSessions">{options}</datalist>
             </>
         );
     }

--- a/app/src/popup/components/ExpandedSessionListInput.js
+++ b/app/src/popup/components/ExpandedSessionListInput.js
@@ -20,10 +20,10 @@ export class ExpandedSessionListInput extends React.Component {
             options.push(<option value={sessionName}></option>);
         }
         return (
-            <>
+            <div className="panel-session-name">
                 <input list="allSessions" type="text" className="session-name-input" placeholder="..." />
                 <datalist id="allSessions">{options}</datalist>
-            </>
+            </div>
         );
     }
 }

--- a/app/src/popup/components/ExpandedSessionListInput.js
+++ b/app/src/popup/components/ExpandedSessionListInput.js
@@ -1,0 +1,24 @@
+import React from "react";
+import Database from "../../engine/Database";
+
+export class ExpandedSessionListInput extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            sessions: []
+        };
+    }
+
+    componentDidMount() {
+        const storage = new Database();
+    }
+
+    render() {
+        return(
+            <>
+            </>
+        );
+    }
+}
+
+export default ExpandedSessionListInput;

--- a/app/src/popup/components/Logo.js
+++ b/app/src/popup/components/Logo.js
@@ -6,10 +6,7 @@ export class Logo extends React.Component {
     }
 
     render() {
-        return(
-            <>
-            </>
-        );
+        return <></>;
     }
 }
 

--- a/app/src/popup/components/Logo.js
+++ b/app/src/popup/components/Logo.js
@@ -6,7 +6,11 @@ export class Logo extends React.Component {
     }
 
     render() {
-        return <></>;
+        return (
+            <div className="panel-plugin-name">
+                <a href="https://github.com/BartoszKlonowski/session-storage">{this.props.extensionName}</a>
+            </div>
+        );
     }
 }
 

--- a/app/src/popup/components/Logo.js
+++ b/app/src/popup/components/Logo.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+export class Logo extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return(
+            <>
+            </>
+        );
+    }
+}
+
+export default Logo;


### PR DESCRIPTION
Popup redesign was made to divide the UI implementation into separate components.

The design was also change to be based on grid, with left for input and right for buttons.
The upper/top part is still for the plugin name as a link to repository.
![SessionEngineExample](https://user-images.githubusercontent.com/70535775/139785517-e0972c93-5b61-4a5c-8b4d-656963482fe1.gif)

For more information about implementation please check the commit messages.