### PR TITLE
Open all tabs in current window

### DIFF
--- a/__tests__/engine.tests.js
+++ b/__tests__/engine.tests.js
@@ -77,34 +77,34 @@ test("All tabs should have window ID replaced with current and correct one", () 
             index: 6,
             pinned: false,
             url: "about:debugging#/runtime/this-firefox",
-            windowId: 1
+            windowId: 1,
         },
         {
             active: true,
             index: 6,
             pinned: false,
             url: "about:debugging#/runtime/this-firefox",
-            windowId: 3
+            windowId: 3,
         },
         {
             active: true,
             index: 6,
             pinned: false,
             url: "about:debugging#/runtime/this-firefox",
-            windowId: 15
+            windowId: 15,
         },
         {
             active: true,
             index: 6,
             pinned: false,
             url: "about:debugging#/runtime/this-firefox",
-            windowId: 8
-        }
+            windowId: 8,
+        },
     ];
 
     const correctWindowId = 1;
     engine.assignTabsToCurrentWindow(tabs, correctWindowId);
-    for(let tab of tabs) {
+    for (let tab of tabs) {
         expect(tab.windowId).toBe(correctWindowId);
     }
 });
@@ -117,34 +117,34 @@ test("All tabs should have window ID replaced with default current window ID for
             index: 6,
             pinned: false,
             url: "about:debugging#/runtime/this-firefox",
-            windowId: 1
+            windowId: 1,
         },
         {
             active: true,
             index: 6,
             pinned: false,
             url: "about:debugging#/runtime/this-firefox",
-            windowId: 3
+            windowId: 3,
         },
         {
             active: true,
             index: 6,
             pinned: false,
             url: "about:debugging#/runtime/this-firefox",
-            windowId: 15
+            windowId: 15,
         },
         {
             active: true,
             index: 6,
             pinned: false,
             url: "about:debugging#/runtime/this-firefox",
-            windowId: 8
-        }
+            windowId: 8,
+        },
     ];
 
     const WINDOW_ID_CURRENT = -2;
     engine.assignTabsToCurrentWindow(tabs, "incorrect window's ID", WINDOW_ID_CURRENT);
-    for(let tab of tabs) {
+    for (let tab of tabs) {
         expect(tab.windowId).toBe(WINDOW_ID_CURRENT);
     }
 });

--- a/__tests__/engine.tests.js
+++ b/__tests__/engine.tests.js
@@ -68,3 +68,83 @@ test("MDN tabs.Tab object is converted successfully to Database Tab internal obj
     expect(Object.prototype.hasOwnProperty.call(dbTab, "url")).toBe(true);
     expect(Object.prototype.hasOwnProperty.call(dbTab, "windowId")).toBe(true);
 });
+
+test("All tabs should have window ID replaced with current and correct one", () => {
+    const engine = new Engine({});
+    let tabs = [
+        {
+            active: true,
+            index: 6,
+            pinned: false,
+            url: "about:debugging#/runtime/this-firefox",
+            windowId: 1
+        },
+        {
+            active: true,
+            index: 6,
+            pinned: false,
+            url: "about:debugging#/runtime/this-firefox",
+            windowId: 3
+        },
+        {
+            active: true,
+            index: 6,
+            pinned: false,
+            url: "about:debugging#/runtime/this-firefox",
+            windowId: 15
+        },
+        {
+            active: true,
+            index: 6,
+            pinned: false,
+            url: "about:debugging#/runtime/this-firefox",
+            windowId: 8
+        }
+    ];
+
+    const correctWindowId = 1;
+    engine.assignTabsToCurrentWindow(tabs, correctWindowId);
+    for(let tab of tabs) {
+        expect(tab.windowId).toBe(correctWindowId);
+    }
+});
+
+test("All tabs should have window ID replaced with default current window ID for incorrect window ID", () => {
+    const engine = new Engine({});
+    let tabs = [
+        {
+            active: true,
+            index: 6,
+            pinned: false,
+            url: "about:debugging#/runtime/this-firefox",
+            windowId: 1
+        },
+        {
+            active: true,
+            index: 6,
+            pinned: false,
+            url: "about:debugging#/runtime/this-firefox",
+            windowId: 3
+        },
+        {
+            active: true,
+            index: 6,
+            pinned: false,
+            url: "about:debugging#/runtime/this-firefox",
+            windowId: 15
+        },
+        {
+            active: true,
+            index: 6,
+            pinned: false,
+            url: "about:debugging#/runtime/this-firefox",
+            windowId: 8
+        }
+    ];
+
+    const WINDOW_ID_CURRENT = -2;
+    engine.assignTabsToCurrentWindow(tabs, "incorrect window's ID", WINDOW_ID_CURRENT);
+    for(let tab of tabs) {
+        expect(tab.windowId).toBe(WINDOW_ID_CURRENT);
+    }
+});

--- a/app/src/engine/Engine.js
+++ b/app/src/engine/Engine.js
@@ -21,10 +21,21 @@ class Engine {
 
     reopenSession(name) {
         const tabsArray = this.db.loadSession(name);
-        for (let tab of tabsArray) {
-            console.log("item in tabsArray: ", tab);
-            browser.tabs.create(tab);
-        }
+        const defaultWindowId = browser.windows.WINDOW_ID_CURRENT;
+        browser.windows
+            .getCurrent()
+            .then((thisWindow) => {
+                this.assignTabsToCurrentWindow(tabsArray, thisWindow.windowId, defaultWindowId);
+            })
+            .catch((error) => {
+                console.error("Could not fetch the current Window ID - assigning to default", error.message);
+                this.assignTabsToCurrentWindow(tabsArray, defaultWindowId, defaultWindowId);
+            })
+            .finally(() => {
+                for (let tab of tabsArray) {
+                    browser.tabs.create(tab);
+                }
+            });
     }
 
     isSessionNameCorrect(name) {
@@ -49,6 +60,12 @@ class Engine {
             url: mdnTabObject.url,
         };
         return dbTab;
+    }
+
+    assignTabsToCurrentWindow(tabs, currentWindowId, defaultWindowId) {
+        for (let tab of tabs) {
+            tab.windowId = currentWindowId && currentWindowId > 0 ? currentWindowId : defaultWindowId;
+        }
     }
 }
 


### PR DESCRIPTION
This pull request fixes #36 
It implements the reopening mechanism based on the current window's ID.

The implementation is done by pulling the ID of current browser window opened by the user, and then the ID is assigned to each tab in the query result.
Finally this query result is pushed to opening loop which handles the opening procedure each tab at a time.

**NOTE:** This pull request removes the `console.log` call which was unnecessary and is probably a legacy artiffact from development.