### PR TITLE
Fix: popup reloads on submit

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
         "es2021": true
     },
     "extends": ["eslint:recommended","plugin:react/recommended"],
+    "parser": "@babel/eslint-parser",
     "parserOptions": {
         "ecmaVersion": 12,
         "sourceType": "module"

--- a/app/src/popup/MainPopupLogic.js
+++ b/app/src/popup/MainPopupLogic.js
@@ -33,6 +33,7 @@ export function getSessionNameFromInput(document) {
 
 export function listenForClicks(document, browser) {
     document.addEventListener("click", (event) => {
+        event.preventDefault();
         const session = getSessionNameFromInput(document);
         browser.tabs
             .query({active: true, currentWindow: true})

--- a/app/src/popup/MainPopupLogic.js
+++ b/app/src/popup/MainPopupLogic.js
@@ -27,7 +27,9 @@ export function handleEventForGivenTab(browser, tabs, event, session) {
 }
 
 export function getSessionNameFromInput(document) {
-    const sessionName = document.getElementsByClassName("session-name-input")[0].value;
+    const sessionNameInput = document.getElementsByClassName("session-name-input")[0];
+    const sessionName = sessionNameInput.value;
+    sessionNameInput.value = "";
     return sessionName;
 }
 

--- a/app/src/popup/components/ActionButton.js
+++ b/app/src/popup/components/ActionButton.js
@@ -8,11 +8,9 @@ export class ActionButton extends React.Component {
 
     render() {
         return (
-            <>
-                <button type="submit" title={this.props.text} id={this.props.name}>
-                    <i id={this.props.name} className={this.props.icon}></i> {this.props.text}
-                </button>
-            </>
+            <button type="submit" title={this.props.text} id={this.props.name}>
+                <i id={this.props.name} className={this.props.icon}></i> {this.props.text}
+            </button>
         );
     }
 }

--- a/app/src/popup/components/ExpandedSessionListInput.js
+++ b/app/src/popup/components/ExpandedSessionListInput.js
@@ -12,7 +12,7 @@ export class ExpandedSessionListInput extends React.Component {
     loadSessions = () => {
         const storage = new Database();
         this.setState({sessions: storage.loadSessions()});
-    }
+    };
 
     componentDidMount() {
         this.loadSessions();
@@ -25,7 +25,13 @@ export class ExpandedSessionListInput extends React.Component {
         }
         return (
             <div className="panel-session-name">
-                <input list="allSessions" type="text" className="session-name-input" onClick={this.loadSessions} placeholder="..." />
+                <input
+                    list="allSessions"
+                    type="text"
+                    className="session-name-input"
+                    onClick={this.loadSessions}
+                    placeholder="..."
+                />
                 <datalist id="allSessions">{options}</datalist>
             </div>
         );

--- a/app/src/popup/components/ExpandedSessionListInput.js
+++ b/app/src/popup/components/ExpandedSessionListInput.js
@@ -9,9 +9,13 @@ export class ExpandedSessionListInput extends React.Component {
         };
     }
 
-    componentDidMount() {
+    loadSessions = () => {
         const storage = new Database();
         this.setState({sessions: storage.loadSessions()});
+    }
+
+    componentDidMount() {
+        this.loadSessions();
     }
 
     render() {
@@ -21,7 +25,7 @@ export class ExpandedSessionListInput extends React.Component {
         }
         return (
             <div className="panel-session-name">
-                <input list="allSessions" type="text" className="session-name-input" onSubmit="return false;" placeholder="..." />
+                <input list="allSessions" type="text" className="session-name-input" onClick={this.loadSessions} placeholder="..." />
                 <datalist id="allSessions">{options}</datalist>
             </div>
         );

--- a/app/src/popup/components/ExpandedSessionListInput.js
+++ b/app/src/popup/components/ExpandedSessionListInput.js
@@ -21,7 +21,7 @@ export class ExpandedSessionListInput extends React.Component {
         }
         return (
             <div className="panel-session-name">
-                <input list="allSessions" type="text" className="session-name-input" placeholder="..." />
+                <input list="allSessions" type="text" className="session-name-input" onSubmit="return false;" placeholder="..." />
                 <datalist id="allSessions">{options}</datalist>
             </div>
         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -305,6 +305,25 @@
         }
       }
     },
+    "@babel/eslint-parser": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz",
+      "integrity": "sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "^5.1.1",
+        "eslint-visitor-keys": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/generator": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@babel/cli": "^7.14.5",
     "@babel/core": "^7.15.8",
+    "@babel/eslint-parser": "^7.17.0",
     "@babel/node": "^7.14.7",
     "@babel/preset-env": "^7.14.7",
     "@babel/preset-react": "^7.14.5",


### PR DESCRIPTION
This pull request fixes #40 
It prevents the whole popup to reload after a button is clicked so there's no "blinking" anymore after making any action.

The implementation contains also:
* clearing the input field after a button is clicked
Previously the input was reset due to whole popup reload, but without the text would stay without this change.
* reloading the stored sessions name when clicked in the input field
The session names were loaded on `componentDidMount`, but this method would not get called if the popup did not reload. So if there's no reload anymore the sessions has to be loaded from storage somewhere.