### PR TITLE
Introduce the reusable `Button` component

### DIFF
--- a/app/src/popup/components/ActionButton.js
+++ b/app/src/popup/components/ActionButton.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Button from "./reusable/Button";
 
 export class ActionButton extends React.Component {
     constructor(props) {
@@ -8,9 +9,10 @@ export class ActionButton extends React.Component {
 
     render() {
         return (
-            <button type="submit" title={this.props.text} id={this.props.name}>
-                <i id={this.props.name} className={this.props.icon}></i> {this.props.text}
-            </button>
+            <Button text={this.props.text} name={this.props.name}>
+                <i id={this.props.name} className={this.props.icon}></i>
+                {this.props.text}
+            </Button>
         );
     }
 }

--- a/app/src/popup/components/reusable/Button.js
+++ b/app/src/popup/components/reusable/Button.js
@@ -23,11 +23,7 @@ export class Button extends React.Component {
     }
 
     render() {
-        if (this.props.buttonType) {
-            return this.renderVariantButton();
-        } else {
-            return this.renderDefaultButton();
-        }
+        return this.props.buttonType ? this.renderVariantButton() : this.renderDefaultButton();
     }
 }
 

--- a/app/src/popup/components/reusable/Button.js
+++ b/app/src/popup/components/reusable/Button.js
@@ -31,4 +31,4 @@ export class Button extends React.Component {
     }
 }
 
-export default ActionButton;
+export default Button;

--- a/app/src/popup/components/reusable/Button.js
+++ b/app/src/popup/components/reusable/Button.js
@@ -1,0 +1,34 @@
+import React from "react";
+
+export class Button extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    renderVariantButton() {
+        return (
+            <button type="submit" className={`${this.props.buttonType}`} title={this.props.text} id={this.props.name}>
+                {this.props.children}
+            </button>
+        );
+    }
+
+    renderDefaultButton() {
+        return (
+            <button type="submit" title={this.props.text} id={this.props.name}>
+                {this.props.children}
+            </button>
+        );
+    }
+
+    render() {
+        if (this.props.buttonType) {
+            return this.renderVariantButton();
+        } else {
+            return this.renderDefaultButton();
+        }
+    }
+}
+
+export default ActionButton;


### PR DESCRIPTION
This pull request creates the reusable `Button` component that can be used for various types of button in the popup body.

The `Button` is able to render any button with given style (if style is given via props) or a default button that is already used in the application as the `ActionButton`.
