### PR TITLE
Repo update - follow-up

### DIFF
--- a/.github/workflows/SessionStorage-CI.yml
+++ b/.github/workflows/SessionStorage-CI.yml
@@ -131,7 +131,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: ./build
-          key: ${{ hashFiles('./app/manifest.json') }}
+          key: ${{ hashFiles('./package.json') }}-${{ hashFiles('./app/manifest.json') }}
 
       - name: Build the release package
         run: npx web-ext build --source-dir "./build"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10095,12 +10095,6 @@
         "webpack-merge": "^5.7.3"
       },
       "dependencies": {
-        "colorette": {
-          "version": "2.0.16",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-          "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
-          "dev": true
-        },
         "commander": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10095,6 +10095,12 @@
         "webpack-merge": "^5.7.3"
       },
       "dependencies": {
+        "colorette": {
+          "version": "2.0.16",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+          "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+          "dev": true
+        },
         "commander": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",


### PR DESCRIPTION
This PR fixes the issue introduced when updating the key for cached compilation results.
The key was not updated for all steps resulting in missing sources causing fail.