### PR TITLE
Accessibility (a11y) improvements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,11 @@
         "browser": true,
         "es2021": true
     },
-    "extends": ["eslint:recommended","plugin:react/recommended"],
+    "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended",
+        "plugin:jsx-a11y/recommended"
+    ],
     "parser": "@babel/eslint-parser",
     "parserOptions": {
         "ecmaVersion": 12,
@@ -19,12 +23,22 @@
         "react/prop-types": 0
     },
     "plugins": [
-        "prettier"
+        "prettier",
+        "jsx-a11y"
     ],
     "globals": {
         "browser": "writable",
         "window": "readonly",
         "test": "writable",
         "expect": "writable"
-    }
+    },
+    "settings": {
+        "jsx-a11y": {
+          "components": {
+            "Logo": "link",
+            "ActionButton": "button",
+            "Button": "button"
+          }
+        }
+      }
 }

--- a/app/src/popup/MainPopup.html
+++ b/app/src/popup/MainPopup.html
@@ -2,6 +2,7 @@
 
 <html>
   <head>
+    <title>session-storage Mozilla Firefox extension</title>
     <meta charset="utf-8">
     <link rel="stylesheet" href="MainPopup.css"/>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">

--- a/app/src/popup/components/ExpandedSessionListInput.js
+++ b/app/src/popup/components/ExpandedSessionListInput.js
@@ -23,6 +23,8 @@ export class ExpandedSessionListInput extends React.Component {
             <div className="panel-session-name">
                 <input
                     list="allSessions"
+                    aria-label={"session-name-input-field"}
+                    aria-required="true"
                     type="text"
                     className="session-name-input"
                     onClick={() => this.setState({sessions: this.state.storage.loadSessions()})}

--- a/app/src/popup/components/ExpandedSessionListInput.js
+++ b/app/src/popup/components/ExpandedSessionListInput.js
@@ -22,6 +22,7 @@ export class ExpandedSessionListInput extends React.Component {
         return (
             <div className="panel-session-name">
                 <input
+                    title="Name of session"
                     list="allSessions"
                     aria-label={"session-name-input-field"}
                     aria-required="true"

--- a/app/src/popup/components/Logo.js
+++ b/app/src/popup/components/Logo.js
@@ -8,7 +8,7 @@ export class Logo extends React.Component {
     render() {
         return (
             <div className="panel-plugin-name">
-                <a href="https://github.com/BartoszKlonowski/session-storage">{this.props.extensionName}</a>
+                <a href="https://github.com/BartoszKlonowski/session-storage" title="Click to visit GH Page">{this.props.extensionName}</a>
             </div>
         );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1318,6 +1318,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.18.6.tgz",
+      "integrity": "sha512-cOu5wH2JFBgMjje+a+fz2JNIWU4GzYpl05oSob3UDvBEh6EuIn+TXFHMmBbhSb+k/4HMzgKCQfEEDArAWNF9Cw==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.20.2",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
@@ -2907,6 +2917,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
+      }
+    },
     "array-differ": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
@@ -2965,6 +2985,12 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
+      "dev": true
+    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -3005,6 +3031,18 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true
+    },
+    "axe-core": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.2.tgz",
+      "integrity": "sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==",
+      "dev": true
+    },
+    "axobject-query": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
+      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
     },
     "babel-jest": {
@@ -3800,6 +3838,12 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.23.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.23.3.tgz",
+      "integrity": "sha512-XpoouuqIj4P+GWtdyV8ZO3/u4KftkeDVMfvp+308eGMhCrA3lVDSmAxO0c6GGOcmgVlaKDrgWVMo49h2ab/TDA==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -3877,6 +3921,12 @@
           "dev": true
         }
       }
+    },
+    "damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
@@ -4494,6 +4544,60 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
       "dev": true
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.0.tgz",
+      "integrity": "sha512-kTeLuIzpNhXL2CwLlc8AHI0aFRwWHcg483yepO9VQiHzM9bZwJdzTkzBszbuPrbgGmq2rlX/FaT2fJQsjUSHsw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "aria-query": "^4.2.2",
+        "array-includes": "^3.1.5",
+        "ast-types-flow": "^0.0.7",
+        "axe-core": "^4.4.2",
+        "axobject-query": "^2.2.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^3.3.1",
+        "language-tags": "^1.0.5",
+        "minimatch": "^3.1.2",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.18.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz",
+          "integrity": "sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "emoji-regex": {
+          "version": "9.2.2",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+          "dev": true
+        },
+        "jsx-ast-utils": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz",
+          "integrity": "sha512-4ZCADZHRkno244xlNnn4AOG6sRQ7iBZ5BbgZ4vW4y5IZw7cVUD1PPeblm1xx/nfmMxPdt/LHsXZW8z/j58+l9Q==",
+          "dev": true,
+          "requires": {
+            "array-includes": "^3.1.5",
+            "object.assign": "^4.1.2"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "eslint-plugin-no-unsanitized": {
       "version": "4.0.1",
@@ -7413,6 +7517,21 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
+    },
+    "language-subtag-registry": {
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
+      "integrity": "sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==",
+      "dev": true
+    },
+    "language-tags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
+      "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
+      "dev": true,
+      "requires": {
+        "language-subtag-registry": "~0.3.2"
+      }
     },
     "latest-version": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-react-app": "^10.0.0",
     "eslint": "^7.28.0",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-jsx-a11y": "^6.6.0",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.26.1",
     "jest": "^27.0.5",


### PR DESCRIPTION
This pull request introduces some improvements to the extension's accessibility.
The improvements are:
* Use labels for all elements to suggest/describe the element
* Add text for screen reader to the session name input for more feedback on focus
* Add title to the whole document

There are also some internal improvement: the project now uses the `jsx-a11y` plugin for ESLint to check against the fields, where accessibility is still not good enough.

The changes were tested using [Thunder](https://www.webbie.org.uk/thunder/) screenreader.