### PR TITLE
Fix: Session's name doesn't fit in tile

### DIFF
--- a/app/src/popup/MainPopup.css
+++ b/app/src/popup/MainPopup.css
@@ -90,7 +90,7 @@ form {
 
 .session-tile-name {
   padding: 2px;
-  width: 200px;
+  width: 220px;
 }
 
 .session-tile-tabs-count {

--- a/app/src/popup/components/SessionsList.js
+++ b/app/src/popup/components/SessionsList.js
@@ -21,7 +21,9 @@ const SessionTile = ({name, onSelect}) => {
             tabIndex={name}
             onClick={onSelect}
             onKeyDown={onSelect}>
-            <div className="session-tile-name">{trimmedName}</div>
+            <div className="session-tile-name" title={name}>
+                {trimmedName}
+            </div>
             <div className="session-tile-tabs-count">{tabsCount}</div>
         </div>
     );

--- a/app/src/popup/components/SessionsList.js
+++ b/app/src/popup/components/SessionsList.js
@@ -12,6 +12,8 @@ const SessionTile = ({name, onSelect}) => {
         });
     }, [name]);
 
+    const nameLenghtTreshold = 22;
+    const trimmedName = name.length > nameLenghtTreshold ? name.substring(0, nameLenghtTreshold).concat("...") : name;
     return (
         <div
             className="session-tile-container"
@@ -19,7 +21,7 @@ const SessionTile = ({name, onSelect}) => {
             tabIndex={name}
             onClick={onSelect}
             onKeyDown={onSelect}>
-            <div className="session-tile-name">{name}</div>
+            <div className="session-tile-name">{trimmedName}</div>
             <div className="session-tile-tabs-count">{tabsCount}</div>
         </div>
     );


### PR DESCRIPTION
This pull request fixes #69 
It trims the text to avoid breaking the tile's layout and keeps the full name as a tooltip.
This implementation was checked on both platforms.