### PR TITLE
Bump `actions/upload-artifact` to v3

### DIFF
--- a/.github/workflows/SessionStorage-CI.yml
+++ b/.github/workflows/SessionStorage-CI.yml
@@ -135,7 +135,7 @@ jobs:
         run: npx web-ext build --source-dir "./platforms/mozilla/app" --overwrite-dest
 
       - name: Store the built package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: release-candidate-package-mozilla
           path: ./web-ext-artifacts/*
@@ -144,7 +144,7 @@ jobs:
         run: npx web-ext build --source-dir "./platforms/chromium/app" --overwrite-dest
 
       - name: Store the built package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: release-candidate-package-chromium
           path: ./web-ext-artifacts/*

--- a/.github/workflows/SessionStorage-CI.yml
+++ b/.github/workflows/SessionStorage-CI.yml
@@ -135,7 +135,7 @@ jobs:
         run: npx web-ext build --source-dir "./platforms/mozilla/app" --overwrite-dest
 
       - name: Store the built package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-candidate-package-mozilla
           path: ./web-ext-artifacts/*
@@ -144,7 +144,7 @@ jobs:
         run: npx web-ext build --source-dir "./platforms/chromium/app" --overwrite-dest
 
       - name: Store the built package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-candidate-package-chromium
           path: ./web-ext-artifacts/*


### PR DESCRIPTION
This PR is to fix the failing CI due to deprecated uses.