### PR TITLE
Set the max width to fit the whole content

### DIFF
--- a/app/src/popup/Main.css
+++ b/app/src/popup/Main.css
@@ -1,7 +1,7 @@
 html, body {
   margin: 0;
   padding: none;
-  max-width: 500px;
+  max-width: fit-content;
 }
 
 .hidden {


### PR DESCRIPTION
This is to avoid the app being cut in half when running on Edge (Chromium) platform.